### PR TITLE
Pullrequest: Downgrade Android Sdk to 22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ jdk: oraclejdk7
 android:
   components:
     - build-tools-23.0.1
-    - android-23
+    - android-22
     - extra

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,7 @@ android {
     defaultConfig {
         applicationId "org.simlar"
         minSdkVersion 9
+        //noinspection OldTargetApi
         targetSdkVersion 22
         versionName getGitVersion()
     }
@@ -49,7 +50,9 @@ android {
 dependencies {
     pushCompile 'com.google.android.gms:play-services-gcm:8.1.0'
     compile files('libs/liblinphone.jar')
+    //noinspection GradleDependency
     compile 'com.android.support:appcompat-v7:22.2.1'
     compile 'com.googlecode.libphonenumber:libphonenumber:7.1.0'
+    //noinspection GradleDependency
     compile 'com.android.support:support-v4:22.2.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ android {
 
     lintOptions {
         checkAllWarnings true
-        disable 'UnusedIds', 'IconExpectedSize'
+        disable 'UnusedIds', 'IconExpectedSize', 'AllowBackup'
         warningsAsErrors true
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,13 +10,13 @@ def getGitVersion = { ->
 }
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 22
     buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "org.simlar"
         minSdkVersion 9
-        targetSdkVersion 23
+        targetSdkVersion 22
         versionName getGitVersion()
     }
 
@@ -49,7 +49,7 @@ android {
 dependencies {
     pushCompile 'com.google.android.gms:play-services-gcm:8.1.0'
     compile files('libs/liblinphone.jar')
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:22.2.1'
     compile 'com.googlecode.libphonenumber:libphonenumber:7.1.0'
-    compile 'com.android.support:support-v4:23.0.1'
+    compile 'com.android.support:support-v4:22.2.1'
 }

--- a/app/src/alwaysOnline/AndroidManifest.xml
+++ b/app/src/alwaysOnline/AndroidManifest.xml
@@ -27,7 +27,6 @@
 
     <application
         android:allowBackup="false"
-        android:fullBackupContent="false"
         tools:ignore="UnusedAttribute">
 
         <!-- needed to not warn in push flavour -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,7 +51,6 @@
     <application
         android:name=".App"
         android:allowBackup="false"
-        android:fullBackupContent="false"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="false"

--- a/app/src/main/java/org/simlar/widgets/CreateAccountActivity.java
+++ b/app/src/main/java/org/simlar/widgets/CreateAccountActivity.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -174,23 +173,15 @@ public final class CreateAccountActivity extends Activity
 				return;
 			}
 
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-				final String smsFormat = extras.getString("format");
-				if (smsFormat == null) {
-					Lg.e("received sms with no format");
-					return;
-				}
+			final String smsFormat = extras.getString("format");
+			if (smsFormat == null) {
+				Lg.e("received sms with no format");
+				return;
+			}
 
-				for (final Object pdu : pdus) {
-					final SmsMessage sms = SmsMessage.createFromPdu((byte[]) pdu, smsFormat);
-					onSmsReceived(sms.getOriginatingAddress(), sms.getMessageBody());
-				}
-			} else {
-				for (final Object pdu : pdus) {
-					//noinspection deprecation
-					final SmsMessage sms = SmsMessage.createFromPdu((byte[]) pdu);
-					onSmsReceived(sms.getOriginatingAddress(), sms.getMessageBody());
-				}
+			for (final Object pdu : pdus) {
+				final SmsMessage sms = SmsMessage.createFromPdu((byte[]) pdu, smsFormat);
+				onSmsReceived(sms.getOriginatingAddress(), sms.getMessageBody());
 			}
 		}
 	}

--- a/app/src/main/java/org/simlar/widgets/CreateAccountActivity.java
+++ b/app/src/main/java/org/simlar/widgets/CreateAccountActivity.java
@@ -173,14 +173,8 @@ public final class CreateAccountActivity extends Activity
 				return;
 			}
 
-			final String smsFormat = extras.getString("format");
-			if (smsFormat == null) {
-				Lg.e("received sms with no format");
-				return;
-			}
-
 			for (final Object pdu : pdus) {
-				final SmsMessage sms = SmsMessage.createFromPdu((byte[]) pdu, smsFormat);
+				final SmsMessage sms = SmsMessage.createFromPdu((byte[]) pdu);
 				onSmsReceived(sms.getOriginatingAddress(), sms.getMessageBody());
 			}
 		}

--- a/app/src/push/AndroidManifest.xml
+++ b/app/src/push/AndroidManifest.xml
@@ -34,7 +34,6 @@
 
     <application
         android:allowBackup="false"
-        android:fullBackupContent="false"
         tools:ignore="UnusedAttribute">
 
         <!-- needed to not warn in alwaysOnline flavour -->


### PR DESCRIPTION
*Attention:* This pullrequest is for the 1.6.x branch

Liblinphone does not support Android Sdk 23 at the moment. It crashes on Android 6.0 devices.