### PR TITLE
Pullrequest disable IPv6

### DIFF
--- a/app/src/main/java/org/simlar/service/liblinphone/LinphoneHandler.java
+++ b/app/src/main/java/org/simlar/service/liblinphone/LinphoneHandler.java
@@ -118,6 +118,7 @@ final class LinphoneHandler
 		mLinphoneCore.start();
 		mLinphoneCore.setUserAgent("Simlar", Version.getVersionName(context));
 
+		mLinphoneCore.enableIpv6(false);
 		mLinphoneCore.setNatPolicy(createNatPolicy());
 
 		// Use TLS for registration with random port


### PR DESCRIPTION
  * liblinphone enabled IPv6 in version 4.0 by default. But we discovered connection problems with it.