### PR TITLE
Pullrequest non public DialogFragments crash

### DIFF
--- a/app/src/main/java/org/simlar/widgets/ConnectionDetailsDialogFragment.java
+++ b/app/src/main/java/org/simlar/widgets/ConnectionDetailsDialogFragment.java
@@ -36,7 +36,8 @@ import org.simlar.R;
 import org.simlar.helper.CallConnectionDetails;
 import org.simlar.logging.Lg;
 
-final class ConnectionDetailsDialogFragment extends DialogFragment
+@SuppressWarnings("WeakerAccess") // class must be public otherwise crashes
+public final class ConnectionDetailsDialogFragment extends DialogFragment
 {
 	// gui elements
 	private TextView mTextViewQuality = null;

--- a/app/src/main/java/org/simlar/widgets/VolumesControlDialogFragment.java
+++ b/app/src/main/java/org/simlar/widgets/VolumesControlDialogFragment.java
@@ -37,7 +37,8 @@ import androidx.fragment.app.FragmentActivity;
 import org.simlar.R;
 import org.simlar.logging.Lg;
 
-final class VolumesControlDialogFragment extends DialogFragment
+@SuppressWarnings("WeakerAccess") // class must be public otherwise crashes
+public final class VolumesControlDialogFragment extends DialogFragment
 {
 	private Listener mListener = null;
 


### PR DESCRIPTION
A dependency update since the last stable version 2.2.0 introduced this bug. But I was too lazy to find out which commit it was.