### PR TITLE
Pullrequest backport NPEs detected with liblinphone 4.5

### DIFF
--- a/app/src/main/java/org/simlar/service/liblinphone/LinphoneHandler.java
+++ b/app/src/main/java/org/simlar/service/liblinphone/LinphoneHandler.java
@@ -317,6 +317,10 @@ final class LinphoneHandler
 		}
 
 		final Call call = mLinphoneCore.getCurrentCall();
+		if (call == null) {
+			Lg.e("ERROR in verifyAuthenticationToken: no current call");
+			return;
+		}
 
 		if (!token.equals(call.getAuthenticationToken())) {
 			Lg.e("ERROR in verifyAuthenticationToken: token(", token,

--- a/app/src/main/java/org/simlar/service/liblinphone/LinphoneHandler.java
+++ b/app/src/main/java/org/simlar/service/liblinphone/LinphoneHandler.java
@@ -440,6 +440,11 @@ final class LinphoneHandler
 		}
 
 		final CallParams params = mLinphoneCore.createCallParams(currentCall);
+		if (params == null) {
+			Lg.e("request enable video but failed to create params for current call");
+			return;
+		}
+
 		if (enable && params.videoEnabled()) {
 			Lg.i("request enable video with already enabled video => skipping");
 			return;

--- a/app/src/main/java/org/simlar/service/liblinphone/LinphoneHandler.java
+++ b/app/src/main/java/org/simlar/service/liblinphone/LinphoneHandler.java
@@ -258,6 +258,11 @@ final class LinphoneHandler
 		Lg.i("unregister triggered");
 
 		final ProxyConfig proxyConfig = mLinphoneCore.getDefaultProxyConfig();
+		if (proxyConfig == null) {
+			Lg.e("unregister triggered but no default proxy config");
+			return;
+		}
+
 		proxyConfig.edit();
 		proxyConfig.enableRegister(false);
 		proxyConfig.done();

--- a/app/src/main/java/org/simlar/service/liblinphone/LinphoneThread.java
+++ b/app/src/main/java/org/simlar/service/liblinphone/LinphoneThread.java
@@ -425,7 +425,7 @@ public final class LinphoneThread implements Runnable, CoreListener
 				return "";
 			}
 
-			return mFriend.getAddress().getUsername();
+			return mFriend.getAddress().asString();
 		}
 	}
 

--- a/app/src/main/java/org/simlar/service/liblinphone/LinphoneThread.java
+++ b/app/src/main/java/org/simlar/service/liblinphone/LinphoneThread.java
@@ -27,6 +27,7 @@ import android.view.TextureView;
 
 import androidx.annotation.NonNull;
 
+import org.linphone.core.Address;
 import org.linphone.core.AuthInfo;
 import org.linphone.core.AuthMethod;
 import org.linphone.core.Call;
@@ -447,7 +448,8 @@ public final class LinphoneThread implements Runnable, CoreListener
 		// ProxyConfig is probably mutable => use it only in the calling thread
 		// RegistrationState is immutable
 
-		final String identity = cfg.getIdentityAddress().getUsername();
+		final Address address = cfg.getIdentityAddress();
+		final String identity = address == null ? "" : address.asString();
 
 		mMainThreadHandler.post(() -> {
 			if (Util.equals(mRegistrationState, state)) {


### PR DESCRIPTION
liblinphone 4.5 adds nullable annotations so IntelliJ detects more possible NPEs.
However the fixes do not hurt for previous versions, too.