### PR TITLE
translate ice state

### DIFF
--- a/app/src/main/java/org/simlar/service/liblinphone/LinphoneManager.java
+++ b/app/src/main/java/org/simlar/service/liblinphone/LinphoneManager.java
@@ -53,6 +53,7 @@ import org.linphone.core.Event;
 import org.linphone.core.Friend;
 import org.linphone.core.FriendList;
 import org.linphone.core.GlobalState;
+import org.linphone.core.IceState;
 import org.linphone.core.InfoMessage;
 import org.linphone.core.PayloadType;
 import org.linphone.core.PresenceModel;
@@ -64,6 +65,7 @@ import org.linphone.core.StreamType;
 import org.linphone.core.SubscriptionState;
 import org.linphone.core.VersionUpdateCheckResult;
 
+import org.simlar.R;
 import org.simlar.helper.CallEndReason;
 import org.simlar.helper.FileHelper;
 import org.simlar.helper.FileHelper.NotInitedException;
@@ -485,7 +487,7 @@ public final class LinphoneManager implements CoreListener
 
 		final int upload = getBandwidth(stats.getUploadBandwidth());
 		final int download = getBandwidth(stats.getDownloadBandwidth());
-		final String iceState = stats.getIceState().toString();
+		final String iceState = getIceStateUiString(stats.getIceState());
 		final int jitter = Math.round((stats.getReceiverInterarrivalJitter() + stats.getSenderInterarrivalJitter()) * 1000.0f);
 		final int packetLoss = Math.round((stats.getReceiverLossRate() + stats.getSenderLossRate()) / 2.0f * 10.0f); // sum of up and down stream loss in per mille
 		final long latePackets = stats.getLatePacketsCumulativeNumber();
@@ -517,6 +519,30 @@ public final class LinphoneManager implements CoreListener
 		} else {
 			mListener.onCallStatsChanged(NetworkQuality.fromFloat(quality), duration, codec, iceState, upload, download,
 					jitter, packetLoss, latePackets, roundTripDelay);
+		}
+	}
+
+	private String getIceStateUiString(final IceState iceState)
+	{
+		if (iceState == null) {
+			return mContext.getString(R.string.linphone_ice_state_none);
+		}
+
+		switch (iceState) {
+		case NotActivated:
+			return mContext.getString(R.string.linphone_ice_state_not_activated);
+		case Failed:
+			return mContext.getString(R.string.linphone_ice_state_failed);
+		case InProgress:
+			return mContext.getString(R.string.linphone_ice_state_in_progress);
+		case HostConnection:
+			return mContext.getString(R.string.linphone_ice_state_host_connection);
+		case ReflexiveConnection:
+			return mContext.getString(R.string.linphone_ice_state_reflexive_connection);
+		case RelayConnection:
+			return mContext.getString(R.string.linphone_ice_state_relay_connection);
+		default:
+			return mContext.getString(R.string.linphone_ice_state_unknown);
 		}
 	}
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -72,6 +72,15 @@
     <string name="linphone_call_state_notification_paused">Anruf mit %1$s pausiert</string>
     <string name="linphone_call_state_notification_resuming">Anruf mit %1$s zurückholen</string>
 
+    <string name="linphone_ice_state_none">keiner</string>
+    <string name="linphone_ice_state_not_activated">nicht aktiviert</string>
+    <string name="linphone_ice_state_failed">fehlgeschlagen</string>
+    <string name="linphone_ice_state_in_progress">im Aufbau</string>
+    <string name="linphone_ice_state_host_connection">direkte Verbindung</string>
+    <string name="linphone_ice_state_reflexive_connection">direkte Verbindung mit NAT</string>
+    <string name="linphone_ice_state_relay_connection">weitergeleitete Verbindung</string>
+    <string name="linphone_ice_state_unknown">unbekannt</string>
+
     <string name="network_quality_good">sehr gut</string>
     <string name="network_quality_average">gut</string>
     <string name="network_quality_poor">schlecht</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,15 @@
     <string name="linphone_call_state_notification_paused">paused call with %1$s</string>
     <string name="linphone_call_state_notification_resuming">resuming call with %1$s ended</string>
 
+    <string name="linphone_ice_state_none">none</string>
+    <string name="linphone_ice_state_not_activated">not activated</string>
+    <string name="linphone_ice_state_failed">failed</string>
+    <string name="linphone_ice_state_in_progress">in progress</string>
+    <string name="linphone_ice_state_host_connection">direct connection</string>
+    <string name="linphone_ice_state_reflexive_connection">direct connection with NAT</string>
+    <string name="linphone_ice_state_relay_connection">relay connection</string>
+    <string name="linphone_ice_state_unknown">unknown</string>
+
     <string name="network_quality_good">good</string>
     <string name="network_quality_average">average</string>
     <string name="network_quality_poor">poor</string>


### PR DESCRIPTION
from liblinphone source code `liblinphone/include/linphone/types.h`

```
typedef enum _LinphoneIceState {
        LinphoneIceStateNotActivated = 0, /**< ICE has not been activated for this call or stream*/
        LinphoneIceStateFailed = 1, /**< ICE processing has failed */
        LinphoneIceStateInProgress = 2, /**< ICE process is in progress */
        LinphoneIceStateHostConnection = 3, /**< ICE has established a direct connection to the remote host */
        LinphoneIceStateReflexiveConnection = 4, /**< ICE has established a connection to the remote host through one or several NATs */
        LinphoneIceStateRelayConnection = 5 /**< ICE has established a connection through a relay */
} LinphoneIceState;
```